### PR TITLE
Update aws-sdk to latest 2.x version

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "aws-sdk": "^2.2.21",
+    "aws-sdk": "^2.5.3",
     "batch": "^0.5.3",
     "bluebird": "^3.0.6",
     "chunk": "0.0.2",


### PR DESCRIPTION
The main motivation for the upgrade is to have a version of the SDK that supports [the new IAM Roles for ECS Tasks](http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html). I've deployed this to our ECS cluster, and it picked up the task role as expected.