### PR TITLE
use LRU cache for task definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "koa-route": "^2.4.2",
     "koa-send": "^3.1.0",
     "koa-static": "^2.0.0",
+    "lru-cache": "^4.0.1",
     "ms": "^0.7.1"
   },
   "devDependencies": {

--- a/server/cache.js
+++ b/server/cache.js
@@ -78,7 +78,7 @@ Cache.prototype.poll = function *(){
   let taskCalls = services.map(service => {
     let task = taskCache.get(service.taskDefinition);
     if (task) {
-      return new Promise((resolve, reject) => { resolve(task) });
+      return Promise.resolve(task);
     }
     return ecs.task(service.taskDefinition).then(task => {
       taskCache.set(service.taskDefinition, task);

--- a/server/cache.js
+++ b/server/cache.js
@@ -19,7 +19,8 @@ module.exports = Cache;
 function Cache(ecs){
   Emitter.call(this);
   this.tasks = LRU({
-    max: 10000,
+    max: 1000000,
+    maxAge: ms('1d'),
     length: (val, key) => { val.length }
   });
   this.ecs = ecs;

--- a/server/cache.js
+++ b/server/cache.js
@@ -80,7 +80,7 @@ Cache.prototype.poll = function *(){
     if (task) {
       return new Promise((resolve, reject) => { resolve(task) });
     }
-    return ecs.task(service.taskDefinition).resolve(task => {
+    return ecs.task(service.taskDefinition).then(task => {
       taskCache.set(service.taskDefinition, task);
       return task;
     });

--- a/server/cache.js
+++ b/server/cache.js
@@ -21,7 +21,7 @@ function Cache(ecs){
   this.tasks = LRU({
     max: 1000000,
     maxAge: ms('1d'),
-    length: (val, key) => { val.length }
+    length: (val, key) => 1
   });
   this.ecs = ecs;
   this.cache([], []); // initial state


### PR DESCRIPTION
@calvinedson 
@stephenmathieson 
@rbranson 

This change intends to reduce the amount of requests we make to the ECS APIs, the idea is that task definitions are immutable and therefore don't need to be refetched over and over.

Please take a look, I haven't written JS in a long time so it may be a bit rusty.