### PR TITLE
webpack: add html plugin to remove hacks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,6 @@ dev-server: node_modules
 
 build: node_modules
 	NODE_ENV=production node_modules/.bin/webpack $(WEBPACK_FLAGS)
-	cp client/index.html build/index.html
 
 node_modules: package.json
 	npm install

--- a/client/index.html
+++ b/client/index.html
@@ -3,10 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>Specs - peer into your ECS clusters</title>
-    <link rel="stylesheet" href="/bundle.css">
   </head>
   <body>
     <div id="root"></div>
-    <script src="/bundle.js"></script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "file-loader": "^0.8.5",
     "flatten": "^1.0.2",
     "history": "^1.17.0",
+    "html-webpack-plugin": "^2.24.1",
     "keyname": "^0.1.0",
     "moment": "^2.10.6",
     "nodemon": "^1.8.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const webpack = require('webpack');
 const HMRPlugin = webpack.HotModuleReplacementPlugin;
 const DefinePlugin = webpack.DefinePlugin;
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const HtmlWebpackPlugin = require('html-webpack-plugin')
 const path = require('path');
 
 const env = process.env.NODE_ENV || 'development';
@@ -13,11 +14,11 @@ const config = module.exports = {
   context: path.join(__dirname, 'client'),
   devtool: 'source-map',
   entry: {
-    js: './index.js',
-    html: './index.html',
+    main: './index.js',
   },
   output: {
     path: './build',
+    publicPath: '/',
     filename: 'bundle.js',
   },
   plugins: [
@@ -25,14 +26,14 @@ const config = module.exports = {
       'process.env': {
         NODE_ENV: JSON.stringify(env)
       }
+    }),
+    new HtmlWebpackPlugin({
+      template: 'index.html',
+      inject: 'body'
     })
   ],
   module: {
     loaders: [
-      {
-        test: /\.html$/,
-        loader: 'file?name=[name].[ext]'
-      },
       {
         test: /\.js$/,
         exclude: /node_modules/,
@@ -73,6 +74,5 @@ const config = module.exports = {
 }
 
 if (env == 'production') {
-  delete config.entry.html
   config.plugins.push(new ExtractTextPlugin('bundle.css'))
 }


### PR DESCRIPTION
This patch adds the `html-webpack-plugin` to automatically generate our
HTML rather than requiring hacks during the build.

This also removes the /bundle.css 404 in dev.