### PR TITLE
Add container instance information for clusters

### DIFF
--- a/client/components/container-instance-list/index.css
+++ b/client/components/container-instance-list/index.css
@@ -1,13 +1,22 @@
 
-.ServiceList {
-  list-style: none;
+
+.ContainerListWrapper {
   float: right;
   margin: -5px;
   width: 950px;
-  padding-bottom: 25px;
+  padding-bottom: 100px;
 }
 
-.ServiceListItem {
+.ContainerListWrapper h2 {
+  margin-bottom: .3em;
+}
+
+.ContainerList {
+  list-style: none;
+  padding: 0;
+}
+
+.ContainerListItem {
   display: inline-block;
   width: 216px;
   height: 193px;
@@ -16,13 +25,12 @@
   margin: 5px;
 }
 
-
-.ServiceListItem a {
+.ContainerListItem > div  {
   height: 100%;
   width: 100%;
   display: block;
-  padding-top: 25px;
-  padding-bottom: 25px;
+  padding-top: 15px;
+  padding-bottom: 15px;
   padding-left: 5px;
   padding-right: 5px;
   text-align: center;
@@ -36,23 +44,18 @@
   transform: translateZ(0);
 }
 
-.ServiceListItem a:focus,
-.ServiceListItem a:hover {
-  border-color: #3cc76a;
-}
-
-.ServiceListItem h3 {
+.ContainerListItem h3 {
   margin: 0;
   padding: 0;
-  font-size: 24px;
-  margin-bottom: 15px;
+  font-size: 16px;
+  font-weight: bold;
+  margin-bottom: 0px;
   overflow: hidden;
   white-space: nowrap;
   text-overflow: ellipsis;
 }
 
-
-.ServiceListItem p {
+.ContainerListItem p {
   margin: 0;
   padding: 0;
   text-transform: capitalize;

--- a/client/components/container-instance-list/index.js
+++ b/client/components/container-instance-list/index.js
@@ -1,0 +1,62 @@
+
+import React, { Component } from 'react';
+import classname from 'classname';
+import moment from 'moment';
+import styles from './index.css';
+import ContainerInstanceStats from '../container-instance-stats';
+
+export default class ContainerInstanceList extends Component {
+  render() {
+    const containers = this.matchingContainers();
+
+    if (!containers.length) {
+      return null;
+    }
+
+    return (
+      <div className={styles.ContainerListWrapper}>
+        <h2>Container Instances:</h2>
+        <ul className={styles.ContainerList}>
+          {containers.map(::this.renderContainerItem)}
+        </ul>
+      </div>
+    );
+  }
+
+  renderContainerItem(container, n) {
+    const clusterName = container.clusterArn.split('cluster/')[1];
+    const instanceId = container.ec2InstanceId;
+    return (
+      <li key={n + container.containerInstanceArn} className={styles.ContainerListItem}>
+        <div>
+          <h3>{container.ec2InstanceId}</h3>
+          <ContainerInstanceStats containerInstance={container} />
+        </div>
+      </li>
+    );
+  }
+
+  matchingContainers() {
+    const containers = this.props.containerInstances;
+    const activeClusterArn = this.props.activeClusterArn;
+
+    const filtered = containers.filter(function(container) {
+      if (!activeClusterArn) return false; // don't render if no cluster selected
+      return container.clusterArn === activeClusterArn;
+    });
+
+    // Sort by AZ
+    filtered.sort((left, right) => {
+      const leftVal = left.attributes.find(a => a.name === 'ecs.availability-zone').value;
+      const rightVal = right.attributes.find(a => a.name === 'ecs.availability-zone').value;
+
+      if (leftVal == rightVal) { 
+        return 0;
+      }
+
+      return leftVal < rightVal ? -1 : 1;
+    });
+
+    return filtered;
+  }
+};

--- a/client/components/container-instance-stats/index.css
+++ b/client/components/container-instance-stats/index.css
@@ -1,0 +1,30 @@
+
+.ContainerInstanceStats {}
+
+.ContainerInstanceStats table {
+  font-size: 16px;
+  color: #54585E;
+  width: 100%;
+  table-layout: fixed;
+}
+
+.ContainerInstanceStats th {
+  text-align: right;
+  font-weight: 500;
+  width: 38%;
+}
+
+.ContainerInstanceStats td {
+  text-align: left;
+  padding-left: 7px;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+
+.ContainerInstanceStatsInfo {
+  color: #54585E;
+  font-size: 14px;
+  font-weight: italic;
+  margin-bottom: 5px;
+}

--- a/client/components/container-instance-stats/index.js
+++ b/client/components/container-instance-stats/index.js
@@ -1,0 +1,52 @@
+
+import React, { Component } from 'react';
+import moment from 'moment';
+import styles from './index.css';
+
+export default class ContainerInstanceStats extends Component {
+  render() {
+    const container = this.props.containerInstance;
+    const { 
+      runningTasksCount, 
+      pendingTasksCount, 
+      registeredResources,
+      remainingResources,
+      attributes,
+    } = container;
+
+    const cpuRegistered = registeredResources.find(r => r.name === "CPU");
+    const cpuAvailable = remainingResources.find(r => r.name === "CPU");
+
+    const memRegistered = registeredResources.find(r => r.name === "MEMORY");
+    const memAvailable = remainingResources.find(r => r.name === "MEMORY");
+
+    const instanceType = attributes.find(a => a.name === 'ecs.instance-type').value;
+    const az = attributes.find(a => a.name === 'ecs.availability-zone').value;
+
+    return (
+      <div className={styles.ContainerInstanceStats}>
+        <div className={styles.ContainerInstanceStatsInfo}>
+          <span className="instance-type">{instanceType}</span>
+          {' - '}
+          <span className="az">{az}</span>          
+        </div>
+        <table>
+          <tbody>
+            <tr>
+              <th>Tasks</th>
+              <td>{runningTasksCount}</td>
+            </tr>
+            <tr>
+              <th>CPU</th>
+              <td>{cpuRegistered.integerValue - cpuAvailable.integerValue} / {cpuRegistered.integerValue}</td>
+            </tr>
+            <tr>
+              <th>Memory</th>
+              <td>{memRegistered.integerValue - memAvailable.integerValue} / {memRegistered.integerValue}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+};

--- a/client/components/service-stats/index.js
+++ b/client/components/service-stats/index.js
@@ -20,7 +20,7 @@ export default class ServiceStats extends Component {
           <tbody>
             <tr>
               <th>Image</th>
-              <td>{image}</td>
+              <td title={image}>{image}</td>
             </tr>
             <tr>
               <th>Running</th>

--- a/client/containers/clusters/index.js
+++ b/client/containers/clusters/index.js
@@ -2,13 +2,13 @@
 import React, { Component } from 'react';
 import request from 'superagent';
 import Batch from 'batch';
-import flatten from 'flatten';
 import Loader from 'react-loader';
 import Page from '../../components/page';
 import ErrorMessage from '../../components/error-message';
 import Sidebar from '../../components/sidebar';
 import ServiceList from '../../components/service-list';
 import Service from '../service';
+import ContainerInstanceList from '../../components/container-instance-list';
 
 export default class ClustersContainer extends Component {
   constructor(props, context) {
@@ -17,6 +17,7 @@ export default class ClustersContainer extends Component {
       error: null,
       clusters: [],
       services: [],
+      containerInstances: [],
       activeClusterArn: null,
       activeServiceArn: null
     };
@@ -44,6 +45,10 @@ export default class ClustersContainer extends Component {
             services={this.state.services}
             searchTerm={this.state.searchTerm}
             activeClusterArn={activeClusterArn} />
+          <ContainerInstanceList
+            containerInstances={this.state.containerInstances}
+            activeClusterArn={activeClusterArn}
+          />
         </Loader>
         {this.renderServiceSheet()}
       </Page>
@@ -134,6 +139,22 @@ export default class ClustersContainer extends Component {
   }
 
   /**
+   * Get container instance by its `clusterName` and `containerInstanceArn`.
+   */
+
+  findContainerInstance(clusterName, containerInstanceArn) {
+    const cluster = this.findCluster(clusterName);
+    if (!cluster) {
+      return;
+    }
+
+    return this.state.containerInstances.find((ci) => {
+      return ci.clusterArn === cluster.clusterArn &&
+        ci.containerInstanceArn === containerInstanceArn;
+    });
+  }
+
+  /**
    * Fetch data.
    */
 
@@ -167,10 +188,10 @@ export default class ClustersContainer extends Component {
         return this.setState({ error: err.message });
       }
 
-      const { services } = this.state;
-      services.push(res.body);
+      const { services, containerInstances } = this.state;
       this.setState({
-        services: flatten(services)
+        services: services.concat(res.body.services),
+        containerInstances: containerInstances.concat(res.body.containerInstances),
       });
     }.bind(this));
   }

--- a/server/app.js
+++ b/server/app.js
@@ -71,7 +71,9 @@ app.use(function *(next){
  */
 
 app.use(route.get('/api/clusters', list));
-app.use(route.get('/api/clusters/:cluster', services));
+app.use(route.get('/api/clusters/:cluster', servicesAndContainerInstances));
+app.use(route.get('/api/clusters/:cluster/services', services));
+app.use(route.get('/api/clusters/:cluster/containerInstances', containerInstances));
 app.use(route.get('/api/clusters/:cluster/task/:task', task));
 
 /**
@@ -141,9 +143,36 @@ function *list(){
  * @param {String} cluster
  */
 
+function *servicesAndContainerInstances(cluster){
+  let cache = this.cache;
+  this.body = {
+    services: cache.services(cluster),
+    containerInstances: cache.containerInstances(cluster),
+  };
+}
+
+/**
+ * Returns a json array of a given cluster in
+ * the path parameter.
+ *
+ * @param {String} cluster
+ */
+
 function *services(cluster){
   let cache = this.cache;
   this.body = cache.services(cluster);
+}
+
+/**
+ * Returns a json array of a given cluster in
+ * the path parameter.
+ *
+ * @param {String} cluster
+ */
+
+function *containerInstances(cluster){
+  let cache = this.cache;
+  this.body = cache.containerInstances(cluster);
 }
 
 /**

--- a/server/app.js
+++ b/server/app.js
@@ -137,8 +137,8 @@ function *list(){
 }
 
 /**
- * Returns a json array of a given cluster in
- * the path parameter.
+ * Returns a json array of services and container 
+ * instances for a given cluster in the path parameter.
  *
  * @param {String} cluster
  */
@@ -152,8 +152,8 @@ function *servicesAndContainerInstances(cluster){
 }
 
 /**
- * Returns a json array of a given cluster in
- * the path parameter.
+ * Returns a json array of services for a given cluster
+ * in the path parameter.
  *
  * @param {String} cluster
  */
@@ -164,8 +164,8 @@ function *services(cluster){
 }
 
 /**
- * Returns a json array of a given cluster in
- * the path parameter.
+ * Returns a json array of container instances for 
+ * a given cluster in the path parameter.
  *
  * @param {String} cluster
  */

--- a/server/ecs.js
+++ b/server/ecs.js
@@ -50,6 +50,15 @@ ECS.prototype.services = function(cluster){
     .then(this.describeServices);
 };
 
+
+ECS.prototype.containerInstances = function(cluster){
+  debug('ecs.containerInstances(%s)', cluster);
+  return this.listContainerInstances(cluster)
+    .bind(this)
+    .then(this.describeContainerInstances);
+};
+
+
 /**
  * Lists all the clusters from the API.
  *
@@ -82,7 +91,41 @@ ECS.prototype.describeClusters = function(clusters){
   return new Promise((resolve, reject) => {
     ecs.describeClusters({ clusters: clusters }, (err, data) => {
       if (err) return reject(err);
-      resolve(data);
+      resolve(data);      
+    });
+  });
+}
+
+/**
+ * List container instances for clusters.
+ *
+ * @private
+ * @param {Array[string]} clusters
+ * @return {Promise}
+ */
+
+ECS.prototype.listContainerInstances = function(cluster) {
+  let ecs = this.ecs;
+  debug('ecs.listContainerInstances()'); 
+
+  return new Promise((resolve, reject) => {
+    ecs.listContainerInstances({ cluster }, (err, instanceIds) => {
+      if (err) return reject(err);
+      const containerInstances = instanceIds.containerInstanceArns;
+      resolve([cluster, containerInstances]);
+    });
+  });  
+}
+
+
+
+ECS.prototype.describeContainerInstances = function([cluster, containerInstances]) {
+  let ecs = this.ecs;
+  debug('ecs.listContainerInstances()'); 
+  return new Promise((resolve, reject) => {
+    ecs.describeContainerInstances({ cluster, containerInstances }, (err, instances) => {
+      if (err) return reject(err);
+      resolve(instances.containerInstances.map(ci => Object.assign({ clusterArn: cluster }, ci)));
     });
   });
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,8 +39,8 @@ const config = module.exports = {
         exclude: /node_modules/,
         loaders: [
           'react-hot',
-          'babel'
-        ]
+          'babel?cacheDirectory=./node_modules/.webpack_cache/'
+        ],
       },
       {
         test: /\.css$/,


### PR DESCRIPTION
Added new functionality on the backend to fetch container instance information for clusters.  When viewing a specific cluster on the frontend it lists the containers below the services, with basic information: EC2 instance ID, instance type, AZ, # of running tasks, allocated CPU, and allocated Memory.  Nothing flashy, but now that instance information is available on the front end could easily be extended upon with a slideout like services providing further information.