### PR TITLE
Add panel for viewing tasks running under a service

### DIFF
--- a/client/components/service-tasks/index.css
+++ b/client/components/service-tasks/index.css
@@ -1,0 +1,19 @@
+
+.ServiceTask {
+  display: inline-block;
+  list-style: none;
+  padding: 0;
+  width: calc(100% - 38px);
+  padding: 20px 10px;
+  font-size: 16px;
+  margin-bottom: 10px;
+  border: 1px solid #e3e4e6;
+  border-radius: 4px;
+  box-shadow: 0 1px 0 rgba(0,0,0,.05);
+}
+
+.ServiceTask th {
+  text-align: right;
+  padding-right: 5px;
+  vertical-align: top;
+}

--- a/client/components/service-tasks/index.css
+++ b/client/components/service-tasks/index.css
@@ -3,13 +3,14 @@
   display: inline-block;
   list-style: none;
   padding: 0;
-  width: calc(100% - 38px);
+  box-sizing: border-box;
+  width: 100%;
   padding: 20px 10px;
   font-size: 16px;
   margin-bottom: 10px;
   border: 1px solid #e3e4e6;
   border-radius: 4px;
-  box-shadow: 0 1px 0 rgba(0,0,0,.05);
+  box-shadow: 0 1px 0 rgba(0, 0, 0, 0.05);
 }
 
 .ServiceTask th {

--- a/client/components/service-tasks/index.js
+++ b/client/components/service-tasks/index.js
@@ -1,0 +1,55 @@
+
+import React, { Component } from 'react';
+import moment from 'moment';
+import classname from 'classname';
+import styles from './index.css';
+
+const awsRegion = process.env.AWS_REGION
+
+export default class ServiceTasks extends Component {
+  render() {
+    const { tasks, service, clusterName } = this.props;
+
+    return (
+      <div>
+        {tasks.map((task, index) => {
+          const revision = task.taskDefinitionArn.split("/")[1];
+
+          return (
+            <ul key={`task-${index}`} className={styles.ServiceTask}>
+              <table>
+                <tbody>
+                  <tr>
+                    <th>Task</th>
+                    <td title={task.taskArn}>
+                      <a href={`https://${awsRegion}.console.aws.amazon.com/ecs/home?region=${awsRegion}#/clusters/${clusterName}/tasks/${task.taskArn.split('/')[1]}/details`}>
+                        {task.taskArn.split('/')[1]}
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>task def</th>
+                    <td>
+                      <a href={`https://${awsRegion}.console.aws.amazon.com/ecs/home?region=${awsRegion}#/taskDefinitions/${revision.split(":").join("/")}`}>
+                        {revision}
+                      </a>
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Last status</th>
+                    <td title={task.lastStatus}>{task.lastStatus}</td>
+                  </tr>
+                  <tr>
+                    <th>Desired status</th>
+                    <td title={task.desiredStatus}>{task.desiredStatus}</td>
+                  </tr>
+                </tbody>
+              </table>
+            </ul>
+          )
+        }
+      )}
+      </div>
+    );
+  }
+};

--- a/client/components/service-tasks/index.js
+++ b/client/components/service-tasks/index.js
@@ -6,49 +6,51 @@ import styles from './index.css';
 
 const awsRegion = process.env.AWS_REGION
 
+const Task = ({ task, clusterName }) => {
+  const [family, revision] = task.taskDefinitionArn.split('/');
+  const taskId = task.taskArn.split('/')[0];
+
+  return (
+    <ul className={styles.ServiceTask}>
+      <table>
+        <tbody>
+          <tr>
+            <th>Task</th>
+            <td title={task.taskArn}>
+              <a href={`https://${awsRegion}.console.aws.amazon.com/ecs/home?region=${awsRegion}#/clusters/${clusterName}/tasks/${taskId}/details`}>
+                {taskId}
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <th>task def</th>
+            <td>
+              <a href={`https://${awsRegion}.console.aws.amazon.com/ecs/home?region=${awsRegion}#/taskDefinitions/${family}/${revision}`}>
+                {revision}
+              </a>
+            </td>
+          </tr>
+          <tr>
+            <th>Last status</th>
+            <td title={task.lastStatus}>{task.lastStatus}</td>
+          </tr>
+          <tr>
+            <th>Desired status</th>
+            <td title={task.desiredStatus}>{task.desiredStatus}</td>
+          </tr>
+        </tbody>
+      </table>
+    </ul>
+  );
+}
+
 export default class ServiceTasks extends Component {
   render() {
-    const { tasks, service, clusterName } = this.props;
+    const { tasks, clusterName } = this.props;
 
     return (
       <div>
-        {tasks.map((task, index) => {
-          const revision = task.taskDefinitionArn.split("/")[1];
-
-          return (
-            <ul key={`task-${index}`} className={styles.ServiceTask}>
-              <table>
-                <tbody>
-                  <tr>
-                    <th>Task</th>
-                    <td title={task.taskArn}>
-                      <a href={`https://${awsRegion}.console.aws.amazon.com/ecs/home?region=${awsRegion}#/clusters/${clusterName}/tasks/${task.taskArn.split('/')[1]}/details`}>
-                        {task.taskArn.split('/')[1]}
-                      </a>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>task def</th>
-                    <td>
-                      <a href={`https://${awsRegion}.console.aws.amazon.com/ecs/home?region=${awsRegion}#/taskDefinitions/${revision.split(":").join("/")}`}>
-                        {revision}
-                      </a>
-                    </td>
-                  </tr>
-                  <tr>
-                    <th>Last status</th>
-                    <td title={task.lastStatus}>{task.lastStatus}</td>
-                  </tr>
-                  <tr>
-                    <th>Desired status</th>
-                    <td title={task.desiredStatus}>{task.desiredStatus}</td>
-                  </tr>
-                </tbody>
-              </table>
-            </ul>
-          )
-        }
-      )}
+        {tasks.map((task, i) => <Task key={task.taskArn} task={task} clusterName={clusterName} />)}
       </div>
     );
   }

--- a/client/containers/clusters/index.js
+++ b/client/containers/clusters/index.js
@@ -198,8 +198,8 @@ export default class ClustersContainer extends Component {
     .get(`/api/clusters/${cluster}/tasks/${service}`)
     .end((err, { body }) =>{
       if (err) {
-        err = err || new Error(`unable to fetch tasks in cluster ${cluster.clusterName} family ${service} (${res.status})`);
-        return this.setState({ error: err.message });
+        const message = err.message || `unable to fetch tasks in cluster ${cluster.clusterName} family ${service} (${res.status})`;
+        return this.setState({ error: message });
       }
 
       this.setState({ tasks: this.state.tasks.concat(body)})

--- a/client/containers/clusters/index.js
+++ b/client/containers/clusters/index.js
@@ -17,6 +17,7 @@ export default class ClustersContainer extends Component {
       error: null,
       clusters: [],
       services: [],
+      tasks: [],
       activeClusterArn: null,
       activeServiceArn: null
     };
@@ -93,8 +94,10 @@ export default class ClustersContainer extends Component {
     if (!serviceName) return null;
     const service = this.findService(clusterName, serviceName);
     if (!service) return null;
+    const tasks = this.findTasks(service);
+
     // TODO: if no matching service is found, show an error
-    return <Service service={service} />
+    return <Service service={service} clusterName={clusterName} tasks={tasks} />
   }
 
   /**
@@ -131,6 +134,14 @@ export default class ClustersContainer extends Component {
       return service.clusterArn === cluster.clusterArn &&
         service.serviceName === serviceName;
     });
+  }
+
+  /**
+   * Get all tasks beloning to a service
+   */
+
+  findTasks(service) {
+    return this.state.tasks.filter((task) => `service:${service.serviceName}` === task.group);
   }
 
   /**
@@ -172,6 +183,26 @@ export default class ClustersContainer extends Component {
       this.setState({
         services: flatten(services)
       });
+      res.body.forEach(service => {
+        this.fetchTasks(cluster.clusterName, service.serviceName)
+      })
     }.bind(this));
+  }
+
+  /**
+   * Fetch running tasks for the given `cluster` and `service`.
+   */
+
+  fetchTasks(cluster, service) {
+    request
+    .get(`/api/clusters/${cluster}/tasks/${service}`)
+    .end((err, { body }) =>{
+      if (err) {
+        err = err || new Error(`unable to fetch tasks in cluster ${cluster.clusterName} family ${service} (${res.status})`);
+        return this.setState({ error: err.message });
+      }
+
+      this.setState({ tasks: this.state.tasks.concat(body)})
+    });
   }
 };

--- a/client/containers/service/index.css
+++ b/client/containers/service/index.css
@@ -44,7 +44,5 @@
   background: #fff;
   border: 1px solid #BDC0C5;
   border-top-right-radius: 5px;
-  padding-top: 15px;
-  padding-left: 15px;
-  padding-bottom: 15px;
+  padding: 15px;
 }

--- a/client/containers/service/index.js
+++ b/client/containers/service/index.js
@@ -9,6 +9,7 @@ import { Tabs, TabLink, TabContent } from 'react-tabs-redux';
 import Sheet from '../../components/sheet';
 import ServiceEventList from '../../components/service-event-list';
 import ServiceStats from '../../components/service-stats';
+import ServiceTasks from '../../components/service-tasks';
 import ServiceTaskDef from '../../components/service-task-def';
 import styles from './index.css';
 
@@ -46,6 +47,11 @@ export default class Service extends Component {
                     <TabLink to="events">Events</TabLink>
                   </a>
                 </li>
+                <li>
+                  <a href="#tab=tasks">
+                    <TabLink to="tasks">Tasks</TabLink>
+                  </a>
+                </li>
               </ul>
             </nav>
 
@@ -58,6 +64,13 @@ export default class Service extends Component {
                   family={this.props.service.task.family}
                   revision={this.props.service.task.revision}
                   definition={this.props.service.task.containerDefinitions[0]} />
+              </TabContent>
+              <TabContent for="tasks">
+                <ServiceTasks
+                  clusterName={this.props.clusterName}
+                  service={this.props.service}
+                  tasks={this.props.tasks}
+                />
               </TabContent>
             </div>
           </Tabs>

--- a/client/containers/service/index.js
+++ b/client/containers/service/index.js
@@ -68,7 +68,6 @@ export default class Service extends Component {
               <TabContent for="tasks">
                 <ServiceTasks
                   clusterName={this.props.clusterName}
-                  service={this.props.service}
                   tasks={this.props.tasks}
                 />
               </TabContent>

--- a/server/app.js
+++ b/server/app.js
@@ -72,7 +72,7 @@ app.use(function *(next){
 
 app.use(route.get('/api/clusters', list));
 app.use(route.get('/api/clusters/:cluster', services));
-app.use(route.get('/api/clusters/:cluster/task/:task', task));
+app.use(route.get('/api/clusters/:cluster/tasks/:family', tasks));
 
 /**
  * Static routes.
@@ -153,8 +153,8 @@ function *services(cluster){
  * @param {String} taskArn
  */
 
-function *task(taskArn){
-  let ecs = this.state.ecs;
-  let task = yield ecs.task(taskArn);
+function *tasks(cluster, family){
+  let ecs = this.ecs;
+  let task = yield ecs.tasks(cluster, family);
   this.body = task;
 }


### PR DESCRIPTION
### Overview

* Added server endpoint for fetching tasks for a cluster.
* Added tab for viewing tasks running under a service.

### Future work

* Might want to add the instanceId and a link to the instance a task is running on.

![specs](https://user-images.githubusercontent.com/5478280/32116026-4957d7e4-bb49-11e7-8c40-ba36e73a4c18.png)
