### PR TITLE
opt-out tasks

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -17,7 +17,9 @@ let serve = require('koa-static');
  */
 
 let app = koa();
-let ecs = new ECS(AWS);
+let ecs = new ECS(AWS, {
+  disableTasks: process.env.DISABLE_TASKS
+});
 let cache = new Cache(ecs);
 
 /**

--- a/server/ecs.js
+++ b/server/ecs.js
@@ -15,8 +15,9 @@ module.exports = ECS;
  * @param {AWS} aws - an aws client
  */
 
-function ECS(aws){
+function ECS(aws, opts){
   this.ecs = new aws.ECS();
+  this.disableTasks = opts.disableTasks;
 }
 
 /**
@@ -62,6 +63,10 @@ ECS.prototype.services = function(cluster){
  */
 
 ECS.prototype.tasks = function(cluster, family){
+  if (this.disableTasks) {
+    debug('listing tasks is disabled');
+    return Promise.resolve([]);
+  }
   debug('ecs.tasks(%s)', cluster, family);
   return this.listTasks(cluster, family)
     .bind(this)


### PR DESCRIPTION
This PR is a proposal for making it possible to disable the task list which is causing use to hit rate limits quite a lot. This allows us to preserve most of the features of specs and should only cause the "tasks" tab to show nothing.