### PR TITLE
Fix error when no tasks currently running for a service

### DIFF
--- a/server/ecs.js
+++ b/server/ecs.js
@@ -227,6 +227,9 @@ ECS.prototype.listTasks = function (cluster, family){
 ECS.prototype.describeTasks = function (req){
   debug('ecs.describeTasks called');
   return new Promise((resolve, reject) => {
+    if (req.tasks.length === 0)
+      return resolve([]);
+
     this.ecs.describeTasks(req, (err, res) => {
       if (err) return reject(err);
       resolve(res.tasks);


### PR DESCRIPTION
When requesting the tasks for a service, if the service has no tasks, an error is being thrown and a 404 is returned. That did causes the "Oh no!  An error occured in that request" message to appear.

The underlying reason is because the `describeTasks` was making a request with an empty collection of tasks, which isn't allowed in the API. This PR simply short-circuits the request if no tasks are specified. Now, no more errors, no more 404s, no more "error has occurred" messages! 😄 

Sample error...

```
error: InvalidParameterException: Tasks cannot be empty.
    at Request.extractError (/src/node_modules/aws-sdk/lib/protocol/json.js:48:27)
    at Request.callListeners (/src/node_modules/aws-sdk/lib/sequential_executor.js:106:20)
    at Request.emit (/src/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/src/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/src/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/src/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /src/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/src/node_modules/aws-sdk/lib/request.js:38:9)
    at Request.<anonymous> (/src/node_modules/aws-sdk/lib/request.js:685:12)
    at Request.callListeners (/src/node_modules/aws-sdk/lib/sequential_executor.js:116:18)
    at Request.emit (/src/node_modules/aws-sdk/lib/sequential_executor.js:78:10)
    at Request.emit (/src/node_modules/aws-sdk/lib/request.js:683:14)
    at Request.transition (/src/node_modules/aws-sdk/lib/request.js:22:10)
    at AcceptorStateMachine.runTo (/src/node_modules/aws-sdk/lib/state_machine.js:14:12)
    at /src/node_modules/aws-sdk/lib/state_machine.js:26:10
    at Request.<anonymous> (/src/node_modules/aws-sdk/lib/request.js:38:9)
```