### PR TITLE
Attempt to fix publish step

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -48,4 +48,3 @@ workflows:
             branches:
               only:
                 - master
-                - systemizer/fix-publish

--- a/circle.yml
+++ b/circle.yml
@@ -27,7 +27,7 @@ jobs:
             curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
             sudo pip install awscli==1.11.91
             aws ecr get-login --no-include-email --region $AWS_REGION | sh
-            docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
+            docker login -u $DOCKER_USER -p $DOCKER_PASS
 
       - run:
           name: Build and Publish Docker Images

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Authenticate with AWS and Docker
           command: |
-            curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
+            curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py
             pip install awscli==1.11.91
             aws ecr get-login --no-include-email --region $AWS_REGION | sh
             docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS

--- a/circle.yml
+++ b/circle.yml
@@ -3,7 +3,7 @@ jobs:
   build:
     working_directory: /go/src/github.com/segmentio/specs
     docker:
-      - image: node:6
+      - image: circleci/node:6
     steps:
       - checkout
       - restore_cache:
@@ -17,7 +17,7 @@ jobs:
   publish:
     working_directory: /go/src/github.com/segmentio/specs
     docker:
-      - image: node:6
+      - image: circleci/node:6
     steps:
       - checkout
       - restore_cache:

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ jobs:
       - run:
           name: Authenticate with AWS and Docker
           command: |
-            apt-get update && apt-get install python-dev
+            apt-get update && apt-get install -y python-dev
             curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py
             pip install awscli==1.11.91
             aws ecr get-login --no-include-email --region $AWS_REGION | sh

--- a/circle.yml
+++ b/circle.yml
@@ -6,10 +6,10 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dev-dependency-cache-{{ checksum "package-lock.json" }}
+          key: cache-{{ checksum "package-lock.json" }}
       - run: make node_modules
       - save_cache:
-          key: dev-dependency-cache-{{ checksum "package-lock.json" }}
+          key: cache-{{ checksum "package-lock.json" }}
           paths:
             - ./node_modules
 

--- a/circle.yml
+++ b/circle.yml
@@ -17,6 +17,7 @@ jobs:
     docker:
       - image: circleci/node:6
     steps:
+      - setup_remote_docker
       - checkout
       - restore_cache:
           key: cache-{{ checksum "package-lock.json" }}

--- a/circle.yml
+++ b/circle.yml
@@ -1,7 +1,6 @@
 version: 2
 jobs:
   build:
-    working_directory: /go/src/github.com/segmentio/specs
     docker:
       - image: circleci/node:6
     steps:
@@ -15,7 +14,6 @@ jobs:
             - ./node_modules
 
   publish:
-    working_directory: /go/src/github.com/segmentio/specs
     docker:
       - image: circleci/node:6
     steps:

--- a/circle.yml
+++ b/circle.yml
@@ -25,6 +25,7 @@ jobs:
       - run:
           name: Authenticate with AWS and Docker
           command: |
+            apt-get update && apt-get install python-dev
             curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py
             pip install awscli==1.11.91
             aws ecr get-login --no-include-email --region $AWS_REGION | sh

--- a/circle.yml
+++ b/circle.yml
@@ -25,7 +25,7 @@ jobs:
           command: |
             sudo apt-get update && sudo apt-get install -y python-dev
             curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
-            pip install awscli==1.11.91
+            sudo pip install awscli==1.11.91
             aws ecr get-login --no-include-email --region $AWS_REGION | sh
             docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 

--- a/circle.yml
+++ b/circle.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: dev-dependency-cache-{{ checksum "package-lock.json" }}
+          key: cache-{{ checksum "package-lock.json" }}
       - run:
           name: Authenticate with AWS and Docker
           command: |

--- a/circle.yml
+++ b/circle.yml
@@ -23,8 +23,8 @@ jobs:
       - run:
           name: Authenticate with AWS and Docker
           command: |
-            apt-get update && apt-get install -y python-dev
-            curl -O https://bootstrap.pypa.io/get-pip.py && python get-pip.py
+            sudo apt-get update && sudo apt-get install -y python-dev
+            curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
             pip install awscli==1.11.91
             aws ecr get-login --no-include-email --region $AWS_REGION | sh
             docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS

--- a/circle.yml
+++ b/circle.yml
@@ -25,8 +25,9 @@ jobs:
       - run:
           name: Authenticate with AWS and Docker
           command: |
-            pip install awscli
-            $(aws ecr get-login --region $AWS_REGION)
+            curl -O https://bootstrap.pypa.io/get-pip.py && sudo python get-pip.py
+            pip install awscli==1.11.91
+            aws ecr get-login --no-include-email --region $AWS_REGION | sh
             docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
 
       - run:
@@ -47,3 +48,4 @@ workflows:
             branches:
               only:
                 - master
+                - systemizer/fix-publish


### PR DESCRIPTION
this moves specs to use circlev2 config format (now required). This way the publish step will run on merging with master so we can deploy future changes